### PR TITLE
ViewModel classes exposing a state instead of single data streams

### DIFF
--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/addresult/AddResultFragment.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/addresult/AddResultFragment.kt
@@ -81,21 +81,28 @@ class AddResultFragment : BaseFragment() {
     }
 
     private fun observeViewModels() {
-        viewModelAddResult.saveState.observe(this, Observer { saved -> showResult(saved) })
-        viewModelAddResult.errorState.observe(this, Observer { error -> showError(error) })
+        viewModelAddResult.state.observe(this, Observer { state -> updateState(state) })
     }
 
-    private fun showResult(saved: Boolean) {
-        Log.d(LOG_TAG, "saved workout: $saved")
+
+    private fun updateState(state: AddResultState) {
+        when(state) {
+            is AddResultState.Save -> showResult()
+            is AddResultState.Error -> showError(state.message)
+        }
+    }
+
+    private fun showResult() {
+        Log.d(LOG_TAG, "saved workout")
         textViewError.visibility = View.GONE
         Snackbar.make(view!!, getString(R.string.message_added_workout_result), Snackbar.LENGTH_LONG).show()
         Navigation.findNavController(view!!).navigateUp()
     }
 
-    private fun showError(error: Throwable) {
-        Log.d(LOG_TAG, "Error occured", error)
+    private fun showError(message: String) {
+        Log.d(LOG_TAG, "Error occured: $message")
         textViewError.visibility = View.VISIBLE
-        textViewError.text = error.message
+        textViewError.text = message
     }
 
     private fun onClickDate(view: View) {

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/addresult/AddResultState.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/addresult/AddResultState.kt
@@ -1,0 +1,7 @@
+package de.fklappan.app.workoutlog.ui.addresult
+
+
+sealed class AddResultState {
+    data class Error(val message: String) : AddResultState()
+    object Save : AddResultState()
+}

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/addresult/AddResultViewModel.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/addresult/AddResultViewModel.kt
@@ -14,15 +14,10 @@ class AddResultViewModel(private val useCaseFactory: UseCasesFactory,
                          private val modelMapper: GuiModelMapper) :
     RxViewModel() {
 
-    private val _errorState = MutableLiveData<Throwable>()
+    private val _state = MutableLiveData<AddResultState>()
     // expose read only workoutState
-    val errorState: LiveData<Throwable>
-        get() = _errorState
-
-    private val _saveState = MutableLiveData<Boolean>()
-    // expose read only workoutState
-    val saveState: LiveData<Boolean>
-        get() = _saveState
+    val state: LiveData<AddResultState>
+        get() = _state
 
     fun saveResult(guiModel: WorkoutResultGuiModel) {
         addDisposable(
@@ -37,11 +32,10 @@ class AddResultViewModel(private val useCaseFactory: UseCasesFactory,
     }
 
     private fun handleSuccess() {
-        _saveState.value = true
+        _state.value = AddResultState.Save
     }
 
     private fun handleError(error: Throwable) {
-        _errorState.value = error
+        _state.value = AddResultState.Error(error.localizedMessage)
     }
-
 }

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/addworkout/AddWorkoutFragment.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/addworkout/AddWorkoutFragment.kt
@@ -54,21 +54,27 @@ class AddWorkoutFragment : BaseFragment() {
     }
 
     private fun observeViewModels() {
-        viewModelAddWorkout.saveState.observe(this, Observer { saved -> showResult(saved) })
-        viewModelAddWorkout.errorState.observe(this, Observer { error -> showError(error) })
+        viewModelAddWorkout.state.observe(this, Observer { state -> updateState(state) })
     }
 
-    private fun showResult(saved: Boolean) {
-        Log.d(LOG_TAG, "saved workout: $saved")
+    private fun updateState(state: AddWorkoutState) {
+        when(state) {
+            is AddWorkoutState.Save -> showResult()
+            is AddWorkoutState.Error -> showError(state.message)
+        }
+    }
+
+    private fun showResult() {
+        Log.d(LOG_TAG, "saved workout")
         textViewError.visibility = View.GONE
         Snackbar.make(view!!, getString(R.string.message_saved_workout), Snackbar.LENGTH_LONG).show()
         Navigation.findNavController(view!!).navigateUp()
     }
 
-    private fun showError(error: Throwable) {
-        Log.d(LOG_TAG, "Error occured", error)
+    private fun showError(message: String) {
+        Log.d(LOG_TAG, "Error occured: $message")
         textViewError.visibility = View.VISIBLE
-        textViewError.text = error.message
+        textViewError.text = message
     }
 
 }

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/addworkout/AddWorkoutState.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/addworkout/AddWorkoutState.kt
@@ -1,0 +1,7 @@
+package de.fklappan.app.workoutlog.ui.addworkout
+
+
+sealed class AddWorkoutState {
+    data class Error(val message: String) : AddWorkoutState()
+    object Save : AddWorkoutState()
+}

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/addworkout/AddWorkoutViewModel.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/addworkout/AddWorkoutViewModel.kt
@@ -20,16 +20,10 @@ class AddWorkoutViewModel(private val useCaseFactory: UseCasesFactory,
                           private val modelMapper: GuiModelMapper) :
     RxViewModel() {
 
-
-    private val _errorState = MutableLiveData<Throwable>()
+    private val _state = MutableLiveData<AddWorkoutState>()
     // expose read only workoutState
-    val errorState: LiveData<Throwable>
-        get() = _errorState
-
-    private val _saveState = MutableLiveData<Boolean>()
-    // expose read only workoutState
-    val saveState: LiveData<Boolean>
-        get() = _saveState
+    val state: LiveData<AddWorkoutState>
+        get() = _state
 
     fun saveWorkout(guiModel: WorkoutGuiModel) {
         addDisposable(
@@ -44,11 +38,11 @@ class AddWorkoutViewModel(private val useCaseFactory: UseCasesFactory,
     }
 
     private fun handleSuccess() {
-        _saveState.value = true
+        _state.value = AddWorkoutState.Save
     }
 
     private fun handleError(error: Throwable) {
-        _errorState.value = error
+        _state.value = AddWorkoutState.Error(error.localizedMessage)
     }
 
 }

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/detailviewworkout/DetailviewWorkoutFragment.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/detailviewworkout/DetailviewWorkoutFragment.kt
@@ -80,16 +80,24 @@ class DetailviewWorkoutFragment : BaseFragment() {
     }
 
     private fun observeViewModels() {
-        viewModelDetail.workoutDetailStream.observe(this, Observer { workoutDetails -> showResult(workoutDetails) })
-        viewModelDetail.updateWorkoutStream.observe(this, Observer { workout -> showWorkoutDetails(workout) })
-//        viewModelDetail.errorStream.observe(this, Observer { error -> showError(error)})
+        viewModelDetail.state.observe(this, Observer { state -> updateState(state)})
     }
 
     private fun fetchData() {
         viewModelDetail.loadWorkout(arguments!!.getInt("workoutId"))
     }
 
-    private fun showWorkoutDetails(workoutGuiModel: WorkoutGuiModel) {
+    private fun updateState(state: DetailviewWorkoutState) {
+        when(state) {
+            is DetailviewWorkoutState.Loading -> showLoading()
+            is DetailviewWorkoutState.Error -> showError(state.message)
+            is DetailviewWorkoutState.WorkoutDetails -> showWorkoutDetails(state.workoutDetails)
+            is DetailviewWorkoutState.WorkoutUpdate -> showWorkoutUpdate(state.workout)
+        }
+    }
+
+    private fun showWorkoutUpdate(workoutGuiModel: WorkoutGuiModel) {
+        Log.d(LOG_TAG, "Workout updated")
         textViewWorkoutDetails.text = workoutGuiModel.text
         if (workoutGuiModel.favorite) {
             imageButtonFavorite.imageTintList = ColorStateList.valueOf(context!!.getColor(R.color.colorAccent))
@@ -103,15 +111,23 @@ class DetailviewWorkoutFragment : BaseFragment() {
             .navigate(R.id.action_detailviewWorkoutFragment_to_editWorkoutFragment, arguments)
     }
 
-    private fun showResult(result: WorkoutDetailsGuiModel) {
+    private fun showWorkoutDetails(result: WorkoutDetailsGuiModel) {
         Log.d(LOG_TAG, "Workout details loaded: " + result.workout.text)
         Log.d(LOG_TAG, "Results loaded: " + result.resultList.size)
-        showWorkoutDetails(result.workout)
+        showWorkoutUpdate(result.workout)
 
         val items = ArrayList<WorkoutResultGuiModel>()
         items.addAll(result.resultList)
 
         recyclerViewResults.visibility = View.VISIBLE
         workoutResultAdapter.items = items
+    }
+
+    private fun showLoading() {
+        Log.d(LOG_TAG, "Loading workout details")
+    }
+
+    private fun showError(message: String) {
+        Log.e(LOG_TAG, "Error fetching workout details: $message")
     }
 }

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/detailviewworkout/DetailviewWorkoutState.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/detailviewworkout/DetailviewWorkoutState.kt
@@ -1,0 +1,10 @@
+package de.fklappan.app.workoutlog.ui.detailviewworkout
+
+import de.fklappan.app.workoutlog.ui.overviewworkout.WorkoutGuiModel
+
+sealed class DetailviewWorkoutState {
+    object Loading : DetailviewWorkoutState()
+    data class Error(val message: String) : DetailviewWorkoutState()
+    data class WorkoutDetails(val workoutDetails: WorkoutDetailsGuiModel) : DetailviewWorkoutState()
+    data class WorkoutUpdate(val workout: WorkoutGuiModel) : DetailviewWorkoutState()
+}

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/editworkout/EditWorkoutFragment.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/editworkout/EditWorkoutFragment.kt
@@ -55,26 +55,37 @@ class EditWorkoutFragment : BaseFragment() {
     }
 
     private fun observeViewModels() {
-        viewModel.saveState.observe(this, Observer { saved -> showResult(saved) })
-        viewModel.errorState.observe(this, Observer { error -> showError(error) })
-        viewModel.workoutStream.observe(this, Observer { workout -> showWorkout(workout)})
+        viewModel.state.observe(this, Observer { state -> updateState(state) })
+    }
+
+    private fun updateState(state: EditWorkoutState) {
+        when(state) {
+            is EditWorkoutState.Loading -> showLoading()
+            is EditWorkoutState.Error -> showError(state.message)
+            is EditWorkoutState.Workout -> showWorkout(state.workout)
+            is EditWorkoutState.Save -> showResult()
+        }
+    }
+
+    private fun showLoading() {
+        Log.d(LOG_TAG, "Loading workout")
     }
 
     private fun showWorkout(workout: WorkoutGuiModel) {
         editTextContent.setText(workout.text)
     }
 
-    private fun showResult(saved: Boolean) {
-        Log.d(LOG_TAG, "saved workout: $saved")
+    private fun showResult() {
+        Log.d(LOG_TAG, "saved workout")
         textViewError.visibility = View.GONE
         Snackbar.make(view!!, getString(R.string.message_saved_workout), Snackbar.LENGTH_LONG).show()
         Navigation.findNavController(view!!).navigateUp()
     }
 
-    private fun showError(error: Throwable) {
-        Log.d(LOG_TAG, "Error occured", error)
+    private fun showError(message: String) {
+        Log.e(LOG_TAG, "Error fetching workout: $message")
         textViewError.visibility = View.VISIBLE
-        textViewError.text = error.message
+        textViewError.text = message
     }
 
     private fun fetchData() {

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/editworkout/EditWorkoutState.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/editworkout/EditWorkoutState.kt
@@ -1,0 +1,10 @@
+package de.fklappan.app.workoutlog.ui.editworkout
+
+import de.fklappan.app.workoutlog.ui.overviewworkout.WorkoutGuiModel
+
+sealed class EditWorkoutState {
+    object Loading : EditWorkoutState()
+    data class Error(val message: String) : EditWorkoutState()
+    data class Workout(val workout: WorkoutGuiModel) : EditWorkoutState()
+    object Save : EditWorkoutState()
+}

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/editworkout/EditWorkoutViewModel.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/editworkout/EditWorkoutViewModel.kt
@@ -26,22 +26,13 @@ class EditWorkoutViewModel(private val useCaseFactory: UseCasesFactory,
 
     private lateinit var currentWorkout: WorkoutGuiModel
 
-    private val _workoutStream = MutableLiveData<WorkoutGuiModel>()
-    // expose read only
-    val workoutStream: LiveData<WorkoutGuiModel>
-        get() = _workoutStream
-
-    private val _errorState = MutableLiveData<Throwable>()
+    private val _state = MutableLiveData<EditWorkoutState>()
     // expose read only workoutState
-    val errorState: LiveData<Throwable>
-        get() = _errorState
-
-    private val _saveState = MutableLiveData<Boolean>()
-    // expose read only workoutState
-    val saveState: LiveData<Boolean>
-        get() = _saveState
+    val state: LiveData<EditWorkoutState>
+        get() = _state
 
     fun loadWorkout(workoutId: Int) {
+        _state.value = EditWorkoutState.Loading
         addDisposable(
             useCaseFactory.createGetWorkoutUseCase().execute(workoutId)
                 .subscribeOn(schedulerIo)
@@ -69,15 +60,15 @@ class EditWorkoutViewModel(private val useCaseFactory: UseCasesFactory,
     private fun workoutLoaded(workout: WorkoutDomainModel) {
         // only pass workout to gui, no need for results here
         currentWorkout = modelMapper.mapDomainToGui(workout)
-        _workoutStream.value = currentWorkout
+        _state.value = EditWorkoutState.Workout(currentWorkout)
     }
 
     private fun handleSuccess() {
-        _saveState.value = true
+        _state.value = EditWorkoutState.Save
     }
 
     private fun handleError(error: Throwable) {
-        _errorState.value = error
+        _state.value = EditWorkoutState.Error(error.localizedMessage)
     }
 
 }

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/overviewstatistic/OverviewStatisticFragment.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/overviewstatistic/OverviewStatisticFragment.kt
@@ -44,14 +44,30 @@ class OverviewStatisticFragment : BaseFragment() {
     }
 
     private fun observeViewModels() {
-        viewModelOverviewStatistic.statisticCurrent.observe(this, Observer { showCurrentStatistic(it) })
+        viewModelOverviewStatistic.state.observe(this, Observer { state -> updateState(state) })
     }
 
     private fun fetchData() {
         viewModelOverviewStatistic.loadData()
     }
 
-    private fun showCurrentStatistic(statisticCurrentGuiModel: StatisticCurrentGuiModel) {
+    private fun updateState(state: OverviewStatisticState) {
+        when(state) {
+            is OverviewStatisticState.Loading -> showLoading()
+            is OverviewStatisticState.Error -> showError(state.message)
+            is OverviewStatisticState.Statistic -> showStatistic(state.statistic)
+        }
+    }
+
+    private fun showLoading() {
+        Log.d(LOG_TAG, "Loading statistics")
+    }
+
+    private fun showError(message: String) {
+        Log.e(LOG_TAG, "Error fetching statistics: $message")
+    }
+
+    private fun showStatistic(statisticCurrentGuiModel: StatisticCurrentGuiModel) {
         Log.d(LOG_TAG, "Statistics loaded")
         textViewStreakCount.text = statisticCurrentGuiModel.streak.toString()
         if (statisticCurrentGuiModel.isWorkoutStreak) {

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/overviewstatistic/OverviewStatisticState.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/overviewstatistic/OverviewStatisticState.kt
@@ -1,0 +1,7 @@
+package de.fklappan.app.workoutlog.ui.overviewstatistic
+
+sealed class OverviewStatisticState {
+    object Loading : OverviewStatisticState()
+    data class Error(val message: String) : OverviewStatisticState()
+    data class Statistic(val statistic: StatisticCurrentGuiModel) : OverviewStatisticState()
+}

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/overviewworkout/OverviewWorkoutFragment.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/overviewworkout/OverviewWorkoutFragment.kt
@@ -88,15 +88,31 @@ class OverviewWorkoutFragment : BaseFragment() {
     }
 
     private fun observeViewModels() {
-        viewModelOverviewWorkout.workoutList.observe(this, Observer { workoutList -> showWorkoutList(workoutList) })
-        viewModelOverviewWorkout.updateStream.observe(this, Observer { workout -> updateWorkout(workout) })
+        viewModelOverviewWorkout.state.observe(this, Observer { state -> updateState(state) })
     }
 
     private fun fetchData() {
         viewModelOverviewWorkout.loadWorkouts()
     }
 
-    private fun updateWorkout(workoutGuiModel: WorkoutGuiModel) {
+    private fun updateState(state: OverviewWorkoutState) {
+        when (state) {
+            is OverviewWorkoutState.Loading -> showLoading()
+            is OverviewWorkoutState.Error -> showError(state.message)
+            is OverviewWorkoutState.WorkoutList -> showWorkoutList(state.workouts.toMutableList())
+            is OverviewWorkoutState.WorkoutUpdate -> showWorkoutUpdate(state.workout)
+        }
+    }
+
+    private fun showLoading() {
+        Log.d(LOG_TAG, "Loading workout list")
+    }
+
+    private fun showError(message: String) {
+        Log.e(LOG_TAG, "Error fetching workouts: $message")
+    }
+
+    private fun showWorkoutUpdate(workoutGuiModel: WorkoutGuiModel) {
         Log.d(LOG_TAG, "Updating workout ${workoutGuiModel.workoutId}")
         overviewWorkoutAdapter.update(workoutGuiModel)
     }

--- a/app/src/main/java/de/fklappan/app/workoutlog/ui/overviewworkout/OverviewWorkoutState.kt
+++ b/app/src/main/java/de/fklappan/app/workoutlog/ui/overviewworkout/OverviewWorkoutState.kt
@@ -1,0 +1,8 @@
+package de.fklappan.app.workoutlog.ui.overviewworkout
+
+sealed class OverviewWorkoutState {
+    object Loading : OverviewWorkoutState()
+    data class Error(val message: String) : OverviewWorkoutState()
+    data class WorkoutList(val workouts: List<WorkoutGuiModel>) : OverviewWorkoutState()
+    data class WorkoutUpdate(val workout: WorkoutGuiModel) : OverviewWorkoutState()
+}


### PR DESCRIPTION
all view model classes now expose an MVI like state which contains every necessary information instead of single streams (loading, error, etc.).

also changed unit test to fit new logic.